### PR TITLE
Fix usage of \FUNC{} macro

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -523,7 +523,7 @@ The following list describes the specific changes in \openshmem[1.5]:
 \\ See Section \ref{subsec:shmmallochint} and \ref{subsec:library_constants}.
 %
 \item Added support for nonblocking \ac{AMO} functions.
-\\ See Section \ref{sec:amo-nbi}.
+\\ See Section \ref{subsec:amo_nbi}.
 %
 \item Added support for blocking \OPR{put-with-signal} functions.
 \\ See Section \ref{subsec:shmem_put_signal}.
@@ -756,7 +756,7 @@ The following list describes the specific changes in \openshmem[1.3]:
 %
 \item Added a type-generic interface to \openshmem \ac{RMA} and \ac{AMO}
     operations based on \Cstd[11] Generics.
-\\See Sections \ref{sec:rma}, \ref{sec:rma_nbi} and \ref{sec:amo}.
+\\See Sections \ref{sec:rma} and \ref{sec:amo}.
 %
 \item New nonblocking variants of remote memory access, \FUNC{SHMEM\_PUT\_NBI}
     and \FUNC{SHMEM\_GET\_NBI}.

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -36,7 +36,7 @@ void @\FuncDecl{shmem\_ctx\_getmem}@(shmem_ctx_t ctx, void *dest, const void *so
     \apiargument{IN}{source}{Symmetric address of the source data object.
       The type of \source{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{} arrays.
-      For \func{shmem\_getmem} and \func{shmem\_ctx\_getmem}, elements are bytes.}
+      For \FUNC{shmem\_getmem} and \FUNC{shmem\_ctx\_getmem}, elements are bytes.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}
 

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -37,8 +37,8 @@ void @\FuncDecl{shmem\_ctx\_getmem\_nbi}@(shmem_ctx_t ctx, void *dest, const voi
     \apiargument{IN}{source}{Symmetric address of the source data object.
         The type of \source{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
-        arrays. For \func{shmem\_getmem\_nbi} and
-        \func{shmem\_ctx\_getmem\_nbi}, elements are bytes.}
+        arrays. For \FUNC{shmem\_getmem\_nbi} and
+        \FUNC{shmem\_ctx\_getmem\_nbi}, elements are bytes.}
     \apiargument{IN}{pe}{\ac{PE}  number of the remote \ac{PE}.}
 \end{apiarguments}
 

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -37,7 +37,7 @@ void @\FuncDecl{shmem\_ctx\_putmem}@(shmem_ctx_t ctx, void *dest, const void *so
     \apiargument{IN}{source}{Local address of the data object containing the data to be copied.
       The type of \source{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source} arrays.
-      For \func{shmem\_putmem} and \func{shmem\_ctx\_putmem}, elements are bytes.}
+      For \FUNC{shmem\_putmem} and \FUNC{shmem\_ctx\_putmem}, elements are bytes.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}
 

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -37,7 +37,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_nbi}@(shmem_ctx_t ctx, void *dest, const voi
   \apiargument{IN}{source}{Local address of the object containing the data to be copied.
     The type of \source{} should match that implied in the SYNOPSIS section.}
   \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
-    arrays. For \func{shmem\_putmem\_nbi} and \func{shmem\_ctx\_putmem\_nbi},
+    arrays. For \FUNC{shmem\_putmem\_nbi} and \FUNC{shmem\_ctx\_putmem\_nbi},
     elements are bytes.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -40,8 +40,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     to be copied.
     The type of \source{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
-    arrays. For \func{shmem\_putmem\_signal} and
-    \func{shmem\_ctx\_putmem\_signal}, elements are bytes.}
+    arrays. For \FUNC{shmem\_putmem\_signal} and
+    \FUNC{shmem\_ctx\_putmem\_signal}, elements are bytes.}
     \apiargument{OUT}{sig\_addr}{Symmetric address of the signal data object to
     be updated on the remote \ac{PE} as a signal.}
     \apiargument{IN}{signal}{Unsigned 64-bit value that is used for updating the

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -40,8 +40,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     to be copied.
     The type of \source{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
-    arrays. For \func{shmem\_putmem\_signal\_nbi} and
-    \func{shmem\_ctx\_putmem\_signal\_nbi}, elements are bytes.}
+    arrays. For \FUNC{shmem\_putmem\_signal\_nbi} and
+    \FUNC{shmem\_ctx\_putmem\_signal\_nbi}, elements are bytes.}
     \apiargument{OUT}{sig\_addr}{Symmetric address of the signal data object to
     be updated on the remote \ac{PE} as a signal.}
     \apiargument{IN}{signal}{Unsigned 64-bit value that is used for updating the

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -206,7 +206,7 @@ than or equal to the size of the \openshmem team, then the behavior is undefined
 \subsection{Remote Memory Access Routines}\label{sec:rma}
 \input{content/rma_intro.tex}
 
-\subsubsection{Blocking Remote Memory Access Routines}\label{sec:rma_nbi}
+\subsubsection{Blocking Remote Memory Access Routines}\label{subsec:rma}
 \subsubsubsection{\textbf{SHMEM\_PUT}}\label{subsec:shmem_put}
 \input{content/shmem_put.tex}
 
@@ -225,7 +225,7 @@ than or equal to the size of the \openshmem team, then the behavior is undefined
 \subsubsubsection{\textbf{SHMEM\_IGET}}\label{subsec:shmem_iget}
 \input{content/shmem_iget.tex}
 
-\subsubsection{Nonblocking Remote Memory Access Routines}\label{sec:rma_nbi}
+\subsubsection{Nonblocking Remote Memory Access Routines}\label{subsec:rma_nbi}
 
 \subsubsubsection{\textbf{SHMEM\_PUT\_NBI}}\label{subsec:shmem_put_nbi}
 \input{content/shmem_put_nbi.tex}
@@ -238,7 +238,7 @@ than or equal to the size of the \openshmem team, then the behavior is undefined
 \subsection{Atomic Memory Operations}\label{sec:amo}
 \input{content/atomics_intro}
 
-\subsubsection{Blocking Atomic Memory Operations}\label{sec:amo-nbi}
+\subsubsection{Blocking Atomic Memory Operations}\label{subsec:amo}
 
 \subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH}}
 \label{subsec:shmem_atomic_fetch}
@@ -296,7 +296,7 @@ than or equal to the size of the \openshmem team, then the behavior is undefined
 \label{subsec:shmem_atomic_xor}
 \input{content/shmem_atomic_xor.tex}
 
-\subsubsection{Nonblocking Atomic Memory Operations}\label{sec:amo-nbi}
+\subsubsection{Nonblocking Atomic Memory Operations}\label{subsec:amo_nbi}
 
 \subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_NBI}}
 \label{subsec:shmem_atomic_fetch_nbi}


### PR DESCRIPTION
* Fix capitalization of the `\func` -> `\FUNC` macro. Apologies, this bug came from one of my PRs.
* Fix multiply defined labels (from subsubsubsection update)